### PR TITLE
Bump to 3.0.1

### DIFF
--- a/lib/hisrc-rails/version.rb
+++ b/lib/hisrc-rails/version.rb
@@ -1,3 +1,3 @@
 module HisrcRails
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end


### PR DESCRIPTION
e0dc901 does not help at all unless we increment the version and have rubygems see it as an update. When using jquery-rails 3.1.0 there is now a conflict with the bundle installer.
